### PR TITLE
Added pathPrefix config property of router to allow app to run in subfolder

### DIFF
--- a/packages/entando-router/README.md
+++ b/packages/entando-router/README.md
@@ -15,6 +15,7 @@ run `npm i @entando/router`
 ```js
 {
   "mode": "browser", // history mode, can be 'hash' or 'browser'
+  "pathPrefix": "my-web-context",
   "routes": [
     { "name": "homePage", "path": "/" },
     { "name": "about", "path": "/about" },
@@ -24,6 +25,7 @@ run `npm i @entando/router`
 }
 ```
 - **mode** the history type. Can be 'hash' or 'browser' (default: 'browser')
+- **pathPrefix** optional value to be added to the beginning of every path in order to run app in sub-folder (e.g., '/appbuilder')
 - **routes** an array of objects representing the routes.
   - **name** the route unique name
   - **path** the route path pattern

--- a/packages/entando-router/modules/router/router.js
+++ b/packages/entando-router/modules/router/router.js
@@ -12,6 +12,7 @@ let isTimeTraveling = false;
 
 let routes = null;
 let routeNotFound = null;
+let pathPrefix = null;
 
 export const getHistory = () => history;
 
@@ -23,6 +24,9 @@ export function setRoutes(rts) {
   for (i = 0; i < cnt; i += 1) {
     keys = [];
     route = rts[i];
+    if (pathPrefix) {
+      route.path = pathPrefix + route.path;
+    }
     route.re = pathToRegexp(route.path, keys);
     route.keys = keys;
     route.getPath = compile(route.path);
@@ -148,8 +152,12 @@ export const configStore = (reduxStore) => {
 
 
 export const config = (reduxStore, locConfig) => {
+  pathPrefix = locConfig.pathPrefix || null; // Used in setRoutes, so set this first
   setRoutes(locConfig.routes);
   routeNotFound = locConfig.notFoundRoute;
+  if (pathPrefix) {
+    routeNotFound.path = pathPrefix + routeNotFound.path;
+  }
   setMode(locConfig.mode);
   configStore(reduxStore);
 };

--- a/packages/entando-router/package.json
+++ b/packages/entando-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/router",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "LGPL-2.1",
   "description": "router used with redux for entando frontend applications",
   "keywords": [
@@ -31,6 +31,7 @@
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.3",
     "babel-preset-env": "^1.6.1",
+    "babel-preset-react-app": "^3.1.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.19.1",

--- a/packages/entando-router/package.json
+++ b/packages/entando-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@entando/router",
-  "version": "1.0.4",
+  "version": "1.0.3",
   "license": "LGPL-2.1",
   "description": "router used with redux for entando frontend applications",
   "keywords": [

--- a/packages/entando-router/test/router/router.test.js
+++ b/packages/entando-router/test/router/router.test.js
@@ -265,4 +265,41 @@ describe('router', () => {
       subscription();
     });
   });
+
+  describe('config() with pathPrefix', () => {
+    let subscription;
+    const CONFIG = {
+      mode: 'browser',
+      routes: ROUTES,
+      notFoundRoute: { name: 'notFound', path: '/404' },
+      pathPrefix: '/appbuilder',
+    };
+    let routes;
+    beforeEach(() => {
+      routes = setRoutes(ROUTES);
+    });
+    it('should transform the routes', () => {
+      const mockStore = {
+        dispatch: jest.fn(),
+        subscribe: jest.fn()
+          .mockImplementation((func) => {
+            subscription = func;
+          }),
+        getState: () => ({ router: { location: { } } }),
+      };
+
+      config(mockStore, CONFIG);
+
+      expect(Array.isArray(routes)).toBe(true);
+      expect(routes.length).toBe(3);
+      routes.forEach((route, i) => {
+        expect(route.name).toBe(ROUTES[i].name);
+        expect(route.path).toBe(ROUTES[i].path);
+
+        expect(route.re instanceof RegExp).toBe(true);
+        expect(typeof route.getPath === 'function').toBe(true);
+        expect(Array.isArray(route.keys)).toBe(true);
+      });
+    });
+  });
 });

--- a/packages/entando-router/test/router/router.test.js
+++ b/packages/entando-router/test/router/router.test.js
@@ -267,7 +267,6 @@ describe('router', () => {
   });
 
   describe('config() with pathPrefix', () => {
-    let subscription;
     const CONFIG = {
       mode: 'browser',
       routes: ROUTES,
@@ -281,10 +280,7 @@ describe('router', () => {
     it('should transform the routes', () => {
       const mockStore = {
         dispatch: jest.fn(),
-        subscribe: jest.fn()
-          .mockImplementation((func) => {
-            subscription = func;
-          }),
+        subscribe: jest.fn(),
         getState: () => ({ router: { location: { } } }),
       };
 
@@ -295,6 +291,7 @@ describe('router', () => {
       routes.forEach((route, i) => {
         expect(route.name).toBe(ROUTES[i].name);
         expect(route.path).toBe(ROUTES[i].path);
+        expect(route.path).toMatch(/^\/appbuilder.*/);
 
         expect(route.re instanceof RegExp).toBe(true);
         expect(typeof route.getPath === 'function').toBe(true);


### PR DESCRIPTION
Changes made to support scenarios where app-builder run in a sub-domain, added an optional router config value pathPrefix which will be appended to all route paths, as well as the special 404 path.  

Also updated the readme file and bumped the version number to the next non-published version of the router (1.0.4)