### PR TITLE
SME-5 Refresh Token Feature Integrated in @entando/apimanager

### DIFF
--- a/packages/entando-apimanager/README.md
+++ b/packages/entando-apimanager/README.md
@@ -30,6 +30,7 @@ The resulting state will be:
   currentUser: {
     username: null,
     token: null,
+    refreshToken: null,
   }
 }
 ```
@@ -40,7 +41,7 @@ In your index file or where you initialize the application you have to configure
 import { config, setApi } from '@entando/apimanager';
 import { store } from 'state/store';
 
-config(store, loginPage, landingPage);
+config(store, loginPage, landingPage, refreshTokenConfig);
 store.dispatch(setApi({
   domain: process.env.DOMAIN,
   useMocks: process.env.USE_MOCKS,
@@ -55,6 +56,10 @@ The store should contain both the `api` and `currentUser` reducers.
 `loginPage` is the callback used to redirect the user to the login page when the `logoutUser()` action is being used.
 
 `landingPage` is the callback used to redirect the user to the landing page when the `loginUser()` action is being used.
+
+`refreshTokenConfig` is an optional, refresh token enabler that basically enables the app to use refresh token authentication. Technically, it's a config object must consist of two key-function values, which are:
+- `generateParams` (object) which is a parameter for [Request class](https://developer.mozilla.org/en-US/docs/Web/API/Request) which will be used to call your OAuth Token API (basically similar to login but passes `refresh_token`) to request for new access token. The format of the object is similar to **`Request Object`** except without `mockResponse`, `errors`, and `useAuthentication` props. For more info, see **`"Request Object"`** at the later part of readme.
+- `parseResults` (function; returns a Promise) which is your parsing function which has `response` parameter for you to parse the response object and return the new `access_token` and `refresh_token` in a form of object (e.g. `{ access_token: ..., refresh_token: ... }`).
 
 ### setApi({domain: null, useMocks: true})
 
@@ -73,15 +78,15 @@ This two actions have to be used when logging and logging out a user.
 
 On top of that if any request returns either 401 or 403 status codes the package will logout the user and redirect him to the login page.
 
-### loginUser(username, token)
+### loginUser(username, token, refresh_token=optional)
 
-`loginUser` expects both the username and the token that should be used for requests that require authentication.
+`loginUser` expects the parameters username, token, and refresh token (if indicated) that should be used for requests that require authentication.
 
-This method stores also these credentials in the localStorage and redirects the user to the landing page previously setup when using `apiManager`'s `config()` method.
+This method stores also these credentials in the localStorage and invokes `landingPage` function that is previously setup when using `apiManager`'s `config()` method.
 
 ### logoutUser()
 
-`logoutUser` clears the user credentials both from the state and localStorage and then redirects the user to the login page previously setup when using `apiManager`'s `config()` method.
+`logoutUser` clears the user credentials both from the state and localStorage and then invokes `loginPage` function that is previously setup when using `apiManager`'s `config()` method.
 
 ---
 
@@ -92,7 +97,7 @@ Api requests are being done using any of the `apiManager` available methods:
 - `makeRealRequest` makes the request always againsts the API
 - `makeMockRequest` makes the request always against the mock. This method should only be used when the corresponding API has not been developed yet.
 
-Each method accepts the same arguments: a `request` object and a `page` object.
+Each method accepts the same arguments: a `request` object and a `page` object. 
 
 the `apiManager` also exports a `METHODS` constant containing all the available verbs (POST, PUT, DELETE, GET and PATCH).
 

--- a/packages/entando-apimanager/README.md
+++ b/packages/entando-apimanager/README.md
@@ -78,9 +78,9 @@ This two actions have to be used when logging and logging out a user.
 
 On top of that if any request returns either 401 or 403 status codes the package will logout the user and redirect him to the login page.
 
-### loginUser(username, token, refresh_token=optional)
+### loginUser(username, token, refreshToken=optional)
 
-`loginUser` expects the parameters username, token, and refresh token (if indicated) that should be used for requests that require authentication.
+`loginUser` expects the parameters `username` and `token` that should be used for requests that require authentication. If you have configure the API manager to work with refresh token authentication then you must specify `refreshToken` in order to fully integrate refresh token authentication.
 
 This method stores also these credentials in the localStorage and invokes `landingPage` function that is previously setup when using `apiManager`'s `config()` method.
 

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -126,7 +126,7 @@ export const sendTokensToInterceptor = () => {
 
 const beginInterceptSetup = () => {
   const configIntercept = {
-    shouldIntercept: () => refreshTokenConfig !== null,
+    shouldIntercept: () => getRefreshToken() && refreshTokenConfig !== null,
     authorizeRequest: (request, accessToken) => {
       const authstring = request.headers.get('Authorization');
       if (!authstring) return request;

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -19,7 +19,7 @@ export const METHODS = {
 let store = null;
 let loginPage = () => {};
 let landingPage = () => {};
-let refreshToken = null;
+let refreshTokenConfig = null;
 
 export const goToLoginPage = () => loginPage;
 export const goToLandingPage = () => landingPage;
@@ -127,13 +127,19 @@ export const authIntercept = () => {
 const beginInterceptSetup = () => {
   const configIntercept = {
     // specify if request should be intercepted here we intercept
-    // intercepts only if refreshToken object props is specified
-    shouldIntercept: () => refreshToken !== null,
+    // intercepts only if refreshTokenConfig object props is specified
+    shouldIntercept: () => refreshTokenConfig !== null,
     // no need to change auth params, so just return as it is
-    authorizeRequest: request => request,
+    authorizeRequest: (request, accessToken) => {
+      const authstring = request.headers.get('Authorization').split(' ')[0];
+      if (authstring !== 'Basic') {
+        request.headers.set('Authorization', `Bearer ${accessToken}`);
+      }
+      return request;
+    },
     // create a `Request` object for fetch on renewing access token
     createAccessTokenRequest: (token) => {
-      const request = refreshToken.generateParams(token);
+      const request = refreshTokenConfig.generateParams(token);
       return new Request(
         getCompleteRequestUrl(request),
         getRequestParams(request),
@@ -142,7 +148,7 @@ const beginInterceptSetup = () => {
     // extract the new access token from response,
     // parseResults must have access_token and refresh_token keyprop
     parseAccessToken: response => (
-      refreshToken.parseResults(response)
+      refreshTokenConfig.parseResults(response)
         .then((json) => {
           store.dispatch(setTokenCredentials(json.access_token, json.refresh_token));
           authIntercept();
@@ -157,13 +163,13 @@ export const config = (
   reduxStore,
   newLoginPage = () => {},
   newLandingPage = () => {},
-  newRefreshToken = null,
+  newRefreshTokenConfig = null,
 ) => {
   store = reduxStore;
   landingPage = newLandingPage;
   loginPage = newLoginPage;
-  if (newRefreshToken) {
-    refreshToken = newRefreshToken;
+  if (newRefreshTokenConfig) {
+    refreshTokenConfig = newRefreshTokenConfig;
     beginInterceptSetup();
     authIntercept();
   }

--- a/packages/entando-apimanager/modules/state/current-user/actions.js
+++ b/packages/entando-apimanager/modules/state/current-user/actions.js
@@ -1,5 +1,5 @@
 import { SET_USER, SET_TOKEN, UNSET_USER } from './types';
-import { goToLoginPage, goToLandingPage, authIntercept } from '../../api/apiManager';
+import { goToLoginPage, goToLandingPage, sendTokensToInterceptor } from '../../api/apiManager';
 
 export const setUser = user => ({
   type: SET_USER,
@@ -28,7 +28,7 @@ const tokensToLocalStore = (token, tokenRefresh = '') => {
   localStorage.setItem('token', token);
   if (tokenRefresh) {
     localStorage.setItem('tokenRefresh', tokenRefresh);
-    authIntercept();
+    sendTokensToInterceptor();
   }
 };
 

--- a/packages/entando-apimanager/modules/state/current-user/actions.js
+++ b/packages/entando-apimanager/modules/state/current-user/actions.js
@@ -1,5 +1,5 @@
-import { SET_USER, UNSET_USER } from './types';
-import { goToLoginPage, goToLandingPage } from '../../api/apiManager';
+import { SET_USER, SET_TOKEN, UNSET_USER } from './types';
+import { goToLoginPage, goToLandingPage, authIntercept } from '../../api/apiManager';
 
 export const setUser = user => ({
   type: SET_USER,
@@ -8,26 +8,50 @@ export const setUser = user => ({
   },
 });
 
+export const setToken = payload => ({
+  type: SET_TOKEN,
+  payload,
+});
+
 export const unsetUser = () => ({
   type: UNSET_USER,
   payload: {
     user: {
       username: null,
       token: null,
+      tokenRefresh: null,
     },
   },
 });
 
+const tokensToLocalStore = (token, tokenRefresh = '') => {
+  localStorage.setItem('token', token);
+  if (tokenRefresh) {
+    localStorage.setItem('tokenRefresh', tokenRefresh);
+    authIntercept();
+  }
+};
+
 // thunks
 
-export const loginUser = (username, token) => (dispatch) => {
+export const setTokenCredentials = (token, tokenRefresh = '') => (dispatch) => {
+  dispatch(setToken({
+    token,
+    tokenRefresh,
+  }));
+
+  tokensToLocalStore(token, tokenRefresh);
+};
+
+export const loginUser = (username, token, tokenRefresh = '') => (dispatch) => {
   dispatch(setUser({
     username,
     token,
+    tokenRefresh,
   }));
 
   localStorage.setItem('username', username);
-  localStorage.setItem('token', token);
+  tokensToLocalStore(token, tokenRefresh);
   goToLandingPage()();
 };
 
@@ -36,5 +60,6 @@ export const logoutUser = () => (dispatch) => {
 
   localStorage.removeItem('username');
   localStorage.removeItem('token');
+  localStorage.removeItem('tokenRefresh');
   goToLoginPage()();
 };

--- a/packages/entando-apimanager/modules/state/current-user/reducer.js
+++ b/packages/entando-apimanager/modules/state/current-user/reducer.js
@@ -1,23 +1,31 @@
 import { isEmpty } from '@entando/utils';
 
-import { SET_USER, UNSET_USER } from './types';
+import { SET_USER, SET_TOKEN, UNSET_USER } from './types';
 
 const getInitialState = () => ({
   username: localStorage.getItem('username'),
   token: localStorage.getItem('token'),
+  tokenRefresh: localStorage.getItem('tokenRefresh'),
 });
+
+const doesPayloadHadToken = payload => (
+  !isEmpty(payload.token) &&
+  typeof payload.token === 'string'
+);
 
 const isPayloadValid = payload => (
   !isEmpty(payload.username) &&
-  !isEmpty(payload.token) &&
   typeof payload.username === 'string' &&
-  typeof payload.token === 'string'
+  doesPayloadHadToken(payload)
 );
 
 const reducer = (state = getInitialState(), action = {}) => {
   switch (action.type) {
     case SET_USER: {
       return isPayloadValid(action.payload.user) ? action.payload.user : state;
+    }
+    case SET_TOKEN: {
+      return doesPayloadHadToken(action.payload) ? { ...state, ...action.payload } : state;
     }
     case UNSET_USER: {
       return action.payload.user;

--- a/packages/entando-apimanager/modules/state/current-user/selectors.js
+++ b/packages/entando-apimanager/modules/state/current-user/selectors.js
@@ -11,3 +11,8 @@ export const getToken = createSelector(
   getCurrentUser,
   user => user.token,
 );
+
+export const getTokenRefresh = createSelector(
+  getCurrentUser,
+  user => user.tokenRefresh,
+);

--- a/packages/entando-apimanager/modules/state/current-user/types.js
+++ b/packages/entando-apimanager/modules/state/current-user/types.js
@@ -1,2 +1,3 @@
 export const SET_USER = 'current-user/set-user';
 export const UNSET_USER = 'current-user/unset-user';
+export const SET_TOKEN = 'current-user/set-token';

--- a/packages/entando-apimanager/package.json
+++ b/packages/entando-apimanager/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@entando/messages": "^1.0.4",
     "@entando/utils": "^1.2.0",
+    "@shoutem/fetch-token-intercept": "^0.2.2",
     "lodash": "^4.17.10",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/packages/entando-apimanager/test/state/current-user/actions.test.js
+++ b/packages/entando-apimanager/test/state/current-user/actions.test.js
@@ -46,6 +46,7 @@ describe('current-user actions', () => {
       expect(action).toHaveProperty('payload.user', expect.any(Object));
       expect(action).toHaveProperty('payload.user.username', null);
       expect(action).toHaveProperty('payload.user.token', null);
+      expect(action).toHaveProperty('payload.user.tokenRefresh', null);
     });
   });
 
@@ -57,8 +58,10 @@ describe('current-user actions', () => {
       expect(action).toHaveProperty('type', SET_USER);
       expect(action).toHaveProperty('payload.user.username', 'admin');
       expect(action).toHaveProperty('payload.user.token', 'asdf123');
+      expect(action).toHaveProperty('payload.user.tokenRefresh', '');
       expect(localStorage.setItem).toHaveBeenCalledWith('username', 'admin');
       expect(localStorage.setItem).toHaveBeenCalledWith('token', 'asdf123');
+      expect(localStorage.setItem).not.toHaveBeenCalledWith('tokenRefresh', '');
       expect(LANDING_PAGE).toHaveBeenCalled();
     });
   });
@@ -71,9 +74,45 @@ describe('current-user actions', () => {
       expect(action).toHaveProperty('type', UNSET_USER);
       expect(action).toHaveProperty('payload.user.username', null);
       expect(action).toHaveProperty('payload.user.token', null);
+      expect(action).toHaveProperty('payload.user.tokenRefresh', null);
       expect(localStorage.removeItem).toHaveBeenCalledWith('username');
       expect(localStorage.removeItem).toHaveBeenCalledWith('token');
+      expect(localStorage.removeItem).toHaveBeenCalledWith('tokenRefresh');
       expect(LOGIN_PAGE).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('config with refresh tokens', () => {
+  beforeEach(() => {
+    store = mockStore();
+    config(store, LOGIN_PAGE, LANDING_PAGE, {
+      generateParams: {},
+      parseResults: jest.fn(),
+    });
+  });
+
+  describe('setUser', () => {
+    it('see if tokenRefresh exists in payload', () => {
+      const action = setUser({ username: 'a', token: 'b', tokenRefresh: 'c' });
+      expect(action).toHaveProperty('type', SET_USER);
+      expect(action).toHaveProperty('payload.user.tokenRefresh', 'c');
+    });
+  });
+
+  describe('loginUser', () => {
+    it('stores all in localStorage and calls landingPage function', () => {
+      store.dispatch(loginUser('admin', 'asdf123', 'whatthe456'));
+      expect(store.getActions()).toHaveLength(1);
+      const action = store.getActions()[0];
+      expect(action).toHaveProperty('type', SET_USER);
+      expect(action).toHaveProperty('payload.user.username', 'admin');
+      expect(action).toHaveProperty('payload.user.token', 'asdf123');
+      expect(action).toHaveProperty('payload.user.tokenRefresh', 'whatthe456');
+      expect(localStorage.setItem).toHaveBeenCalledWith('username', 'admin');
+      expect(localStorage.setItem).toHaveBeenCalledWith('token', 'asdf123');
+      expect(localStorage.setItem).toHaveBeenCalledWith('tokenRefresh', 'whatthe456');
+      expect(LANDING_PAGE).toHaveBeenCalled();
     });
   });
 });

--- a/packages/entando-apimanager/test/state/current-user/reducer.test.js
+++ b/packages/entando-apimanager/test/state/current-user/reducer.test.js
@@ -12,14 +12,17 @@ describe('current-user reducer', () => {
     expect(typeof defaultState).toBe('object');
     expect(defaultState).toHaveProperty('username', null);
     expect(defaultState).toHaveProperty('token', null);
+    expect(defaultState).toHaveProperty('tokenRefresh', null);
   });
 
   it('should return predefined values if the localStorage exist', () => {
     localStorage.setItem('username', 'admin');
     localStorage.setItem('token', 'myToken');
+    localStorage.setItem('tokenRefresh', 'myRefreshToken');
     const state = reducer();
     expect(state).toHaveProperty('username', 'admin');
     expect(state).toHaveProperty('token', 'myToken');
+    expect(state).toHaveProperty('tokenRefresh', 'myRefreshToken');
     localStorage.clear();
   });
 
@@ -53,13 +56,15 @@ describe('current-user reducer', () => {
       });
 
       it('should not assign the token status if not a string', () => {
-        const state = reducer(defaultState, setUser({ username: 'nic', token: false }));
+        const state = reducer(defaultState, setUser({ username: 'nic', token: false, tokenRefresh: !0 }));
         expect(state).toHaveProperty('token', null);
+        expect(state).toHaveProperty('tokenRefresh', null);
       });
 
       it('should not assign the token status if it is not defined', () => {
         const state = reducer(defaultState, setUser({ username: 'nic' }));
         expect(state).toHaveProperty('token', null);
+        expect(state).toHaveProperty('tokenRefresh', null);
       });
 
       it('should not assign the token status if the username is not valid', () => {
@@ -70,19 +75,22 @@ describe('current-user reducer', () => {
   });
 
   describe('after action unsetUser', () => {
-    it('should return null username and token', () => {
+    it('should return null username, token, and tokenRefresh', () => {
       const state = reducer(defaultState, unsetUser());
       expect(state).toHaveProperty('username', null);
       expect(state).toHaveProperty('token', null);
+      expect(state).toHaveProperty('tokenRefresh', null);
     });
 
-    it('should return null username and token even after setting a user', () => {
+    it('should return null on username, token, and tokenRefresh even after setting a user', () => {
       let state = reducer(defaultState, setUser({ username: 'nic', token: 'asdf123' }));
       expect(state).toHaveProperty('username', 'nic');
       expect(state).toHaveProperty('token', 'asdf123');
+      expect(state).not.toHaveProperty('tokenRefresh', '');
       state = reducer(defaultState, unsetUser());
       expect(state).toHaveProperty('username', null);
       expect(state).toHaveProperty('token', null);
+      expect(state).toHaveProperty('tokenRefresh', null);
     });
   });
 });

--- a/packages/entando-apimanager/test/state/current-user/selectors.test.js
+++ b/packages/entando-apimanager/test/state/current-user/selectors.test.js
@@ -2,11 +2,13 @@ import {
   getCurrentUser,
   getUsername,
   getToken,
+  getTokenRefresh,
 } from 'state/current-user/selectors';
 
 const currentUser = {
   username: 'nic',
   token: 'asdf123',
+  tokenRefresh: 'whatthe2345',
 };
 
 const STATE = { currentUser };
@@ -22,5 +24,9 @@ describe('current-user selectors', () => {
 
   it('verify getToken selector', () => {
     expect(getToken(STATE)).toEqual(currentUser.token);
+  });
+
+  it('verify getTokenRefresh selector', () => {
+    expect(getTokenRefresh(STATE)).toEqual(currentUser.tokenRefresh);
   });
 });


### PR DESCRIPTION
The concept being used is by using fetch-token-intercept (https://github.com/shoutem/fetch-token-intercept) which basically when it detects a 401 status on a request, this immediately executes refresh token request (/oauth/token) indicated in apimanager's config method, after successfully getting a new token, all requests that were resulted with 401 prior to refresh token call will be executed again but this time, using the new token. This will be only used when `refreshTokenConfig` has been indicated in `config` method and `loginUser` has been called with the parameter refresh token.

To test this, follow the steps below (using app-builder as test subject):

1. In frontend-libraries, run `npm run clean` and `npm run bootstrap` 
2. copy `dist` folder in `apimanager` folder and paste it to `app-builder/node-modules/@entando/apimanager`. This overwrites the current `dist` folder in said location.
3. also just copy `node-modules/@shoutem/fetch-token-intercept` to `app-builder/node-modules`
4. now shift to app-builder. In `api/login.js`, add:
```
export const createRefreshTokenParams = token => ({
  uri: '/api/oauth/token',
  method: METHODS.POST,
  contentType: 'application/x-www-form-urlencoded',
  headers: {
    Authorization: `Basic ${btoa(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`)}`,
  },
  body: {
    refresh_token: token,
    grant_type: 'refresh_token',
  },
});
```
5. in `api-init/apiManager.js`, add:
 - `import { createRefreshTokenParams } from 'api/login';`
 - replace the old config method call with the code block below:
```
config(
  store,
  () => gotoRoute(ROUTE_HOME),
  () => gotoRoute(ROUTE_DASHBOARD),
  {
    generateParams: token => createRefreshTokenParams(token),
    parseResults: response => (
      response.json()
        .then(json => (json.payload ? json.payload : json))
    ),
  },
);
```
6. in `state/login-form/actions.js`, look for `loginUser` dispatch call and just add json.refresh_token as third parameter. e.g.:
```
dispatch(loginUser(
   username,
   json.access_token || json.payload.access_token,
   json.refresh_token || json.payload.refresh_token,
));
```
7. `npm start`, then login. After login, you should see the `tokenRefresh` local storage under devtools.
8. usually takes an hour that existing token will be expired, backend returns 401 when token is expired. this will immediately throw a refresh token fetch and renews existing token/tokenRefresh. You will notice that under network tab in devtools. After fetching refresh token, this will re-execute the called requests with 401 error.

Note: ~I have not used entando-pwa as example since I noticed it wasn't recognizing refresh_token request. I noticed in Postman it works fine, so now I am currently investigating this matter.~ this now works in PWA.