### PR TITLE
EN6-34

### DIFF
--- a/packages/entando-apimanager/README.md
+++ b/packages/entando-apimanager/README.md
@@ -56,11 +56,13 @@ The store should contain both the `api` and `currentUser` reducers.
 
 `landingPage` is the callback used to redirect the user to the landing page when the `loginUser()` action is being used.
 
-### setApi({domain: null, useMocks: true})
+### setApi({domain: null, useMocks: true, pathPrefix: ''})
 
 `setApi()` is used to switch the use of mocks on or off. `useMocks` can only be set to false if a domain is being passed.
 
 `domain` has to be a valid domain main, which can omit the protocol. It is possible to add up to one directory, but the domain should not have trailing slashes.
+
+`pathPrefix` is the prefix of the URL path of requests. This can be overriden by specifying a value for the `path` property of a request.
 
 The `wasUpdated` selector will return a boolean to indicate whether or not the `setApi` action was successful.
 
@@ -102,6 +104,7 @@ The request object has the following properties:
 
 ```js
 {
+  path: '',
   uri: '/api/myApi',
   method: METHODS.POST,
   mockResponse: BODY_OK,

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -130,7 +130,7 @@ const getRequestParams = (request) => {
 const getCompleteRequestUrl = (request, page) => {
   const path = request.path || getPathPrefix(store.getState()) || '';
   const domain = getDomain(store.getState());
-  const url = path[0] === '/' && domain === '/' ? `${path}${request.uri}` : `${domain}${path}${request.uri}`;
+  const url = path.charAt(0) === '/' && domain === '/' ? `${path}${request.uri}` : `${domain}${path}${request.uri}`;
   if (!page || !page.page) {
     return url;
   }

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -2,7 +2,7 @@ import 'whatwg-fetch';
 import { throttle, isEmpty } from '@entando/utils';
 
 import { buildResponse, buildErrorResponse, ErrorI18n } from './responseFactory';
-import { useMocks, getDomain } from '../state/api/selectors';
+import { useMocks, getDomain, getDefaultPath } from '../state/api/selectors';
 import { logoutUser } from '../state/current-user/actions';
 import { getToken } from '../state/current-user/selectors';
 import enLocale from '../locales/en';
@@ -128,7 +128,9 @@ const getRequestParams = (request) => {
 };
 
 const getCompleteRequestUrl = (request, page) => {
-  const url = `${getDomain(store.getState())}${request.uri}`;
+  const path = request.path || getDefaultPath(store.getState()) || '';
+  const domain = getDomain(store.getState());
+  const url = path[0] === '/' && domain === '/' ? `${path}${request.uri}` : `${domain}${path}${request.uri}`;
   if (!page || !page.page) {
     return url;
   }

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -2,7 +2,7 @@ import 'whatwg-fetch';
 import { throttle, isEmpty } from '@entando/utils';
 
 import { buildResponse, buildErrorResponse, ErrorI18n } from './responseFactory';
-import { useMocks, getDomain, getDefaultPath } from '../state/api/selectors';
+import { useMocks, getDomain, getPathPrefix } from '../state/api/selectors';
 import { logoutUser } from '../state/current-user/actions';
 import { getToken } from '../state/current-user/selectors';
 import enLocale from '../locales/en';
@@ -128,7 +128,7 @@ const getRequestParams = (request) => {
 };
 
 const getCompleteRequestUrl = (request, page) => {
-  const path = request.path || getDefaultPath(store.getState()) || '';
+  const path = request.path || getPathPrefix(store.getState()) || '';
   const domain = getDomain(store.getState());
   const url = path[0] === '/' && domain === '/' ? `${path}${request.uri}` : `${domain}${path}${request.uri}`;
   if (!page || !page.page) {

--- a/packages/entando-apimanager/modules/state/api/reducer.js
+++ b/packages/entando-apimanager/modules/state/api/reducer.js
@@ -3,6 +3,7 @@ import { SET_API } from './types';
 const initialState = {
   useMocks: true,
   domain: null,
+  defaultPath: '',
   updated: false,
 };
 

--- a/packages/entando-apimanager/modules/state/api/reducer.js
+++ b/packages/entando-apimanager/modules/state/api/reducer.js
@@ -3,7 +3,7 @@ import { SET_API } from './types';
 const initialState = {
   useMocks: true,
   domain: null,
-  defaultPath: '',
+  pathPrefix: '',
   updated: false,
 };
 

--- a/packages/entando-apimanager/modules/state/api/selectors.js
+++ b/packages/entando-apimanager/modules/state/api/selectors.js
@@ -12,9 +12,9 @@ export const getDomain = createSelector(
   api => api.domain,
 );
 
-export const getDefaultPath = createSelector(
+export const getPathPrefix = createSelector(
   getApi,
-  api => api.defaultPath,
+  api => api.pathPrefix,
 );
 
 export const wasUpdated = createSelector(

--- a/packages/entando-apimanager/modules/state/api/selectors.js
+++ b/packages/entando-apimanager/modules/state/api/selectors.js
@@ -12,6 +12,11 @@ export const getDomain = createSelector(
   api => api.domain,
 );
 
+export const getDefaultPath = createSelector(
+  getApi,
+  api => api.defaultPath,
+);
+
 export const wasUpdated = createSelector(
   getApi,
   api => api.updated,

--- a/packages/entando-apimanager/test/api/apiManager.test.js
+++ b/packages/entando-apimanager/test/api/apiManager.test.js
@@ -256,6 +256,43 @@ describe('apiManager', () => {
       }).catch(done.fail);
     });
 
+    it('fetches using a subpath when path is provided', (done) => {
+      const result = makeRequest({ ...validRequest, path: '/adsense' });
+      expect(fetch).toHaveBeenCalledWith(
+        '//google.com/adsense/api/test',
+        {
+          method: validRequest.method,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      expect(result).toBeInstanceOf(Promise);
+      result.then((data) => {
+        expect(data).toMatchObject(REAL_GOOD_RESPONSE);
+        done();
+      }).catch(done.fail);
+    });
+
+    it('fetches using a subpath when path is provided', (done) => {
+      config(mockStore({ ...REAL, api: { ...REAL.api, domain: '/', defaultPath: '/inbox' } }));
+      const result = makeRequest({ ...validRequest, path: '/adsense' });
+      expect(fetch).toHaveBeenCalledWith(
+        '/adsense/api/test',
+        {
+          method: validRequest.method,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      );
+      expect(result).toBeInstanceOf(Promise);
+      result.then((data) => {
+        expect(data).toMatchObject(REAL_GOOD_RESPONSE);
+        done();
+      }).catch(done.fail);
+    });
+
     it('appends the page to the uri when there is no query string', () => {
       makeRequest(validRequest, { page: 1, pageSize: 10 });
       expect(fetch).toHaveBeenCalledWith(

--- a/packages/entando-apimanager/test/api/apiManager.test.js
+++ b/packages/entando-apimanager/test/api/apiManager.test.js
@@ -275,7 +275,7 @@ describe('apiManager', () => {
     });
 
     it('fetches using a subpath when path is provided', (done) => {
-      config(mockStore({ ...REAL, api: { ...REAL.api, domain: '/', defaultPath: '/inbox' } }));
+      config(mockStore({ ...REAL, api: { ...REAL.api, domain: '/', pathPrefix: '/inbox' } }));
       const result = makeRequest({ ...validRequest, path: '/adsense' });
       expect(fetch).toHaveBeenCalledWith(
         '/adsense/api/test',

--- a/packages/entando-apimanager/test/state/api/reducer.test.js
+++ b/packages/entando-apimanager/test/state/api/reducer.test.js
@@ -17,6 +17,13 @@ describe('api reducer', () => {
 
   describe('after action setApi', () => {
     describe('domain', () => {
+      it('should assign the domain with / and defaultPath', () => {
+        const state = reducer(defaultState, setApi({ domain: '/', useMocks: false, defaultPath: '/entando-de-app' }));
+        expect(state).toHaveProperty('domain', '/');
+        expect(state).toHaveProperty('defaultPath', '/entando-de-app');
+        expect(state).toHaveProperty('useMocks', false);
+      });
+
       it('should assign the domain status with only root path', () => {
         const state = reducer(defaultState, setApi({ domain: '/entando-de-app', useMocks: false }));
         expect(state).toHaveProperty('domain', '/entando-de-app');

--- a/packages/entando-apimanager/test/state/api/reducer.test.js
+++ b/packages/entando-apimanager/test/state/api/reducer.test.js
@@ -17,10 +17,10 @@ describe('api reducer', () => {
 
   describe('after action setApi', () => {
     describe('domain', () => {
-      it('should assign the domain with / and defaultPath', () => {
-        const state = reducer(defaultState, setApi({ domain: '/', useMocks: false, defaultPath: '/entando-de-app' }));
+      it('should assign the domain with / and pathPrefix', () => {
+        const state = reducer(defaultState, setApi({ domain: '/', useMocks: false, pathPrefix: '/entando-de-app' }));
         expect(state).toHaveProperty('domain', '/');
-        expect(state).toHaveProperty('defaultPath', '/entando-de-app');
+        expect(state).toHaveProperty('pathPrefix', '/entando-de-app');
         expect(state).toHaveProperty('useMocks', false);
       });
 

--- a/packages/entando-apimanager/test/state/api/selectors.test.js
+++ b/packages/entando-apimanager/test/state/api/selectors.test.js
@@ -3,12 +3,14 @@ import {
   useMocks,
   getDomain,
   wasUpdated,
+  getPathPrefix,
 } from 'state/api/selectors';
 
 const api = {
   useMocks: false,
   domain: '//mydomain.com',
   updated: false,
+  pathPrefix: '/entando',
 };
 
 const STATE = { api };
@@ -28,5 +30,9 @@ describe('api selectors', () => {
 
   it('verify wasUpdated selector', () => {
     expect(wasUpdated(STATE)).toEqual(api.updated);
+  });
+
+  it('verify getPathPrefix selector', () => {
+    expect(getPathPrefix(STATE)).toEqual(api.pathPrefix);
   });
 });


### PR DESCRIPTION
adding a way to have custom paths to enable digital exchange as a separate service (in a subpath other than entando-app), retro compatibility kept