### PR TITLE
accepts multipart/form-data content type

### DIFF
--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -117,8 +117,14 @@ const getRequestParams = (request) => {
       ...request.headers,
     },
   };
+  const isFormData = request.contentType === 'multipart/form-data';
+  if (isFormData) {
+    delete requestParams.headers['Content-Type'];
+  }
   if ([METHODS.POST, METHODS.PUT, METHODS.PATCH].includes(request.method)) {
-    requestParams.body = getParsedBody(request.contentType, request.body);
+    requestParams.body = isFormData
+      ? request.body
+      : getParsedBody(request.contentType, request.body);
   }
   if (request.useAuthentication) {
     requestParams.headers.Authorization = `Bearer ${getAuthenticationToken()}`;

--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -110,17 +110,16 @@ const getParsedBody = (contentType, body) => {
 };
 
 const getRequestParams = (request) => {
+  const isFormData = request.contentType === 'multipart/form-data';
+  const contentTypeHeader = !isFormData ? { 'Content-Type': request.contentType || 'application/json' } : {};
+
   const requestParams = {
     method: request.method,
     headers: {
-      'Content-Type': request.contentType || 'application/json',
+      ...contentTypeHeader,
       ...request.headers,
     },
   };
-  const isFormData = request.contentType === 'multipart/form-data';
-  if (isFormData) {
-    delete requestParams.headers['Content-Type'];
-  }
   if ([METHODS.POST, METHODS.PUT, METHODS.PATCH].includes(request.method)) {
     requestParams.body = isFormData
       ? request.body


### PR DESCRIPTION
digital asset edit (CMS) is using formdata as file upload and since our apimanager does not accept formdata, I have updated this in order for us to use FormData as post body.