### PR TITLE
ENG-2368: return server message if it is defined

### DIFF
--- a/packages/entando-apimanager/modules/api/apiManager.js
+++ b/packages/entando-apimanager/modules/api/apiManager.js
@@ -172,10 +172,14 @@ const getCompleteRequestUrl = (request, params = {}) => {
 
 const normalizeErrorMessage = (message) => {
   if (['noJsonReturned', 'permissionDenied', 'badRequest', 'serviceUnavailable'].includes(message)) {
-    return message;
+    return `app.${message}`;
   }
 
-  return 'serverError';
+  if (!message) {
+    return 'app.serverError';  
+  }
+
+  return message;
 };
 
 export const makeRealRequest = (request, page) => {
@@ -209,7 +213,7 @@ export const makeRealRequest = (request, page) => {
       ? e.response.json()
       : Promise.resolve({ errors: [] });
     return promise.then(({ errors }) => {
-      const message = `app.${normalizeErrorMessage(e.message)}`;
+      const message = normalizeErrorMessage(e.message);
       return Promise.reject(new ErrorI18n(
         message,
         defaultMessages[message],


### PR DESCRIPTION
We were overwriting the message returned by the API if the request fail, this change will only return `app.serverError` if the API does not provide an error message.